### PR TITLE
Type validation of mfa_token and oob_code in oob exchange

### DIFF
--- a/lib/exchange/oob.js
+++ b/lib/exchange/oob.js
@@ -36,10 +36,12 @@ module.exports = function(options, authenticate, issue) {
       , token = req.body.mfa_token
       , oobCode = req.body.oob_code
       , scope = req.body.scope;
-    
+
     if (!token) { return next(new TokenError('Missing required parameter: mfa_token', 'invalid_request')); }
+    if (typeof token !== 'string') { return next(new TokenError('mfa_token must be a string', 'invalid_request')); }
     if (!oobCode) { return next(new TokenError('Missing required parameter: oob_code', 'invalid_request')); }
-    
+    if (typeof oobCode !== 'string') { return next(new TokenError('oob_code must be a string', 'invalid_request')); }
+
     if (scope) {
       for (var i = 0, len = separators.length; i < len; i++) {
         var separated = scope.split(separators[i]);

--- a/test/exchange/oob.test.js
+++ b/test/exchange/oob.test.js
@@ -136,7 +136,40 @@ describe('exchange.oob', function() {
       expect(err.status).to.equal(400);
     });
   });
-  
+
+  describe('handling a request with bad typed MFA token', function() {
+    var response, err;
+
+    before(function(done) {
+      function authenticate(token, done) {
+        return done(null, { id: '0' })
+      }
+
+      function issue(client, user, oobCode, done) {
+        return done(null, '.ignore')
+      }
+
+      chai.connect.use(oob(authenticate, issue))
+        .req(function(req) {
+          req.user = { id: 'c123', name: 'Example' };
+          req.body = { oob_code: 'a1b2c3', mfa_token: { foo: 'bar' } };
+        })
+        .next(function(e) {
+          err = e;
+          done();
+        })
+        .dispatch();
+    });
+
+    it('should error', function() {
+      expect(err).to.be.an.instanceOf(Error);
+      expect(err.constructor.name).to.equal('TokenError');
+      expect(err.message).to.equal('mfa_token must be a string');
+      expect(err.code).to.equal('invalid_request');
+      expect(err.status).to.equal(400);
+    });
+  });
+
   describe('handling a request without an OOB code', function() {
     var response, err;
 
@@ -165,6 +198,39 @@ describe('exchange.oob', function() {
       expect(err).to.be.an.instanceOf(Error);
       expect(err.constructor.name).to.equal('TokenError');
       expect(err.message).to.equal('Missing required parameter: oob_code');
+      expect(err.code).to.equal('invalid_request');
+      expect(err.status).to.equal(400);
+    });
+  });
+
+  describe('handling a request with a bad typed OOB code', function() {
+    var response, err;
+
+    before(function(done) {
+      function authenticate(token, done) {
+        return done(null, { id: '0' })
+      }
+
+      function issue(client, user, oobCode, done) {
+        return done(null, '.ignore')
+      }
+
+      chai.connect.use(oob(authenticate, issue))
+        .req(function(req) {
+          req.user = { id: 'c123', name: 'Example' };
+          req.body = { oob_code: { foo: 'bar' }, mfa_token: 'ey...' };
+        })
+        .next(function(e) {
+          err = e;
+          done();
+        })
+        .dispatch();
+    });
+
+    it('should error', function() {
+      expect(err).to.be.an.instanceOf(Error);
+      expect(err.constructor.name).to.equal('TokenError');
+      expect(err.message).to.equal('oob_code must be a string');
       expect(err.code).to.equal('invalid_request');
       expect(err.status).to.equal(400);
     });


### PR DESCRIPTION
Since the exchange validates that `mfa_token` and `oob_code` is present and calls `issue` with those, the `issue` function should be able to expect that those are strings.

This PR adds type validation into the oob exchange for `mfa_token` and `oob_code`.