### PR TITLE
Verify parameter types for OTP and recovery-code

### DIFF
--- a/lib/exchange/oob.js
+++ b/lib/exchange/oob.js
@@ -18,17 +18,6 @@ module.exports = function(options, authenticate, issue) {
   
   var userProperty = options.userProperty || 'user';
   
-  // For maximum flexibility, multiple scope spearators can optionally be
-  // allowed.  This allows the server to accept clients that separate scope
-  // with either space or comma (' ', ',').  This violates the specification,
-  // but achieves compatibility with existing client libraries that are already
-  // deployed.
-  var separators = options.scopeSeparator || ' ';
-  if (!Array.isArray(separators)) {
-    separators = [ separators ];
-  }
-  
-  
   return function oob(req, res, next) {
     // The 'user' property of `req` holds the authenticated user.  In the case
     // of the token endpoint, the property will contain the OAuth 2.0 client.

--- a/lib/exchange/otp.js
+++ b/lib/exchange/otp.js
@@ -18,44 +18,18 @@ module.exports = function(options, authenticate, issue) {
   
   var userProperty = options.userProperty || 'user';
   
-  // For maximum flexibility, multiple scope spearators can optionally be
-  // allowed.  This allows the server to accept clients that separate scope
-  // with either space or comma (' ', ',').  This violates the specification,
-  // but achieves compatibility with existing client libraries that are already
-  // deployed.
-  var separators = options.scopeSeparator || ' ';
-  if (!Array.isArray(separators)) {
-    separators = [ separators ];
-  }
-  
-  
   return function otp(req, res, next) {
     // The 'user' property of `req` holds the authenticated user.  In the case
     // of the token endpoint, the property will contain the OAuth 2.0 client.
     var client = req[userProperty]
       , token = req.body.mfa_token
-      , oneTimePassword = req.body.otp
-      , scope = req.body.scope;
+      , oneTimePassword = req.body.otp;
     
     if (!token) { return next(new TokenError('Missing required parameter: mfa_token', 'invalid_request')); }
     if (typeof token !== 'string') { return next(new TokenError('mfa_token must be a string', 'invalid_request')); }
     if (!oneTimePassword) { return next(new TokenError('Missing required parameter: otp', 'invalid_request')); }
     if (typeof oneTimePassword !== 'string') { return next(new TokenError('otp must be a string', 'invalid_request')); }
 
-    
-    if (scope) {
-      for (var i = 0, len = separators.length; i < len; i++) {
-        var separated = scope.split(separators[i]);
-        // only separate on the first matching separator.  this allows for a sort
-        // of separator "priority" (ie, favor spaces then fallback to commas)
-        if (separated.length > 1) {
-          scope = separated;
-          break;
-        }
-      }
-      if (!Array.isArray(scope)) { scope = [ scope ]; }
-    }
-    
     function authenticated(err, user, info) {
       if (err) { return next(err); }
       
@@ -83,13 +57,13 @@ module.exports = function(options, authenticate, issue) {
       try {
         var arity = issue.length;
         if (arity == 8) {
-          issue(client, user, oneTimePassword, scope, req.body, info, req.authInfo, issued);
+          issue(client, user, oneTimePassword, token, req.body, info, req.authInfo, issued);
         } else if (arity == 7) {
-          issue(client, user, oneTimePassword, scope, req.body, info, issued);
+          issue(client, user, oneTimePassword, token, req.body, info, issued);
         } else if (arity == 6) {
-          issue(client, user, oneTimePassword, scope, req.body, issued);
+          issue(client, user, oneTimePassword, token, req.body, issued);
         } else if (arity == 5) {
-          issue(client, user, oneTimePassword, scope, issued);
+          issue(client, user, oneTimePassword, token, issued);
         } else { // arity == 4
           issue(client, user, oneTimePassword, issued);
         }

--- a/lib/exchange/otp.js
+++ b/lib/exchange/otp.js
@@ -38,7 +38,10 @@ module.exports = function(options, authenticate, issue) {
       , scope = req.body.scope;
     
     if (!token) { return next(new TokenError('Missing required parameter: mfa_token', 'invalid_request')); }
+    if (typeof token !== 'string') { return next(new TokenError('mfa_token must be a string', 'invalid_request')); }
     if (!oneTimePassword) { return next(new TokenError('Missing required parameter: otp', 'invalid_request')); }
+    if (typeof oneTimePassword !== 'string') { return next(new TokenError('otp must be a string', 'invalid_request')); }
+
     
     if (scope) {
       for (var i = 0, len = separators.length; i < len; i++) {

--- a/lib/exchange/recoveryCode.js
+++ b/lib/exchange/recoveryCode.js
@@ -38,7 +38,10 @@ module.exports = function(options, authenticate, issue) {
       , scope = req.body.scope;
     
     if (!token) { return next(new TokenError('Missing required parameter: mfa_token', 'invalid_request')); }
+    if (typeof token !== 'string') { return next(new TokenError('mfa_token must be a string', 'invalid_request')); }
     if (!recoveryCode) { return next(new TokenError('Missing required parameter: recovery_code', 'invalid_request')); }
+    if (typeof recoveryCode !== 'string') { return next(new TokenError('recovery_code must be a string', 'invalid_request')); }
+
     
     if (scope) {
       for (var i = 0, len = separators.length; i < len; i++) {

--- a/lib/exchange/recoveryCode.js
+++ b/lib/exchange/recoveryCode.js
@@ -18,44 +18,18 @@ module.exports = function(options, authenticate, issue) {
   
   var userProperty = options.userProperty || 'user';
   
-  // For maximum flexibility, multiple scope spearators can optionally be
-  // allowed.  This allows the server to accept clients that separate scope
-  // with either space or comma (' ', ',').  This violates the specification,
-  // but achieves compatibility with existing client libraries that are already
-  // deployed.
-  var separators = options.scopeSeparator || ' ';
-  if (!Array.isArray(separators)) {
-    separators = [ separators ];
-  }
-  
-  
   return function recovery_code(req, res, next) {
     // The 'user' property of `req` holds the authenticated user.  In the case
     // of the token endpoint, the property will contain the OAuth 2.0 client.
     var client = req[userProperty]
       , token = req.body.mfa_token
-      , recoveryCode = req.body.recovery_code
-      , scope = req.body.scope;
+      , recoveryCode = req.body.recovery_code;
     
     if (!token) { return next(new TokenError('Missing required parameter: mfa_token', 'invalid_request')); }
     if (typeof token !== 'string') { return next(new TokenError('mfa_token must be a string', 'invalid_request')); }
     if (!recoveryCode) { return next(new TokenError('Missing required parameter: recovery_code', 'invalid_request')); }
     if (typeof recoveryCode !== 'string') { return next(new TokenError('recovery_code must be a string', 'invalid_request')); }
 
-    
-    if (scope) {
-      for (var i = 0, len = separators.length; i < len; i++) {
-        var separated = scope.split(separators[i]);
-        // only separate on the first matching separator.  this allows for a sort
-        // of separator "priority" (ie, favor spaces then fallback to commas)
-        if (separated.length > 1) {
-          scope = separated;
-          break;
-        }
-      }
-      if (!Array.isArray(scope)) { scope = [ scope ]; }
-    }
-    
     function authenticated(err, user, info) {
       if (err) { return next(err); }
       
@@ -83,13 +57,13 @@ module.exports = function(options, authenticate, issue) {
       try {
         var arity = issue.length;
         if (arity == 8) {
-          issue(client, user, recoveryCode, scope, req.body, info, req.authInfo, issued);
+          issue(client, user, recoveryCode, token, req.body, info, req.authInfo, issued);
         } else if (arity == 7) {
-          issue(client, user, recoveryCode, scope, req.body, info, issued);
+          issue(client, user, recoveryCode, token, req.body, info, issued);
         } else if (arity == 6) {
-          issue(client, user, recoveryCode, scope, req.body, issued);
+          issue(client, user, recoveryCode, token, req.body, issued);
         } else if (arity == 5) {
-          issue(client, user, recoveryCode, scope, issued);
+          issue(client, user, recoveryCode, token, issued);
         } else { // arity == 4
           issue(client, user, recoveryCode, issued);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth2orize-mfa",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Multi-Factor Authentication exchanges for OAuth2orize.",
   "keywords": [
     "oauth",

--- a/test/exchange/oob.test.js
+++ b/test/exchange/oob.test.js
@@ -29,7 +29,7 @@ describe('exchange.oob', function() {
         return done(null, { id: '1', username: 'johndoe' })
       }
       
-      function issue(client, user, oobCode, token, scope, done) {
+      function issue(client, user, oobCode, token, done) {
         if (client.id !== 'c123') { return done(new Error('incorrect client argument')); }
         if (user.username !== 'johndoe') { return done(new Error('incorrect user argument')); }
         if (oobCode !== 'a1b2c3') { return done(new Error('incorrect oobCode argument')); }
@@ -41,7 +41,7 @@ describe('exchange.oob', function() {
       chai.connect.use(oob(authenticate, issue))
         .req(function(req) {
           req.user = { id: 'c123', name: 'Example' };
-          req.body = { mfa_token: 'ey...', oob_code: 'a1b2c3', scope: 'execute' };
+          req.body = { mfa_token: 'ey...', oob_code: 'a1b2c3' };
         })
         .end(function(res) {
           response = res;
@@ -193,7 +193,7 @@ describe('exchange.oob', function() {
     });
   });
 
-  describe('authenticating and issuing with info and body', function() {
+  describe('authenticating and issuing with token, body, and info', function() {
     var response, err;
 
     before(function(done) {
@@ -208,7 +208,7 @@ describe('exchange.oob', function() {
         if (user.username !== 'johndoe') { return done(new Error('incorrect user argument')); }
         if (oobCode !== 'a1b2c3') { return done(new Error('incorrect oobCode argument')); }
         if (token !== 'ey...') { return done(new Error('incorrect token argument')); }
-        if (body.mfa_token !== 'ey...' || body.oob_code !== 'a1b2c3' || body.scope !== 'execute'  ) {
+        if (body.mfa_token !== 'ey...' || body.oob_code !== 'a1b2c3' ) {
           return done(new Error('incorrect body argument'));
         }
         if (info.provider !== 'XXX') { return done(new Error('incorrect info argument')); }
@@ -219,7 +219,7 @@ describe('exchange.oob', function() {
       chai.connect.use(oob(authenticate, issue))
         .req(function(req) {
           req.user = { id: 'c123', name: 'Example' };
-          req.body = { mfa_token: 'ey...', oob_code: 'a1b2c3', scope: 'execute' };
+          req.body = { mfa_token: 'ey...', oob_code: 'a1b2c3' };
         })
         .end(function(res) {
           response = res;

--- a/test/exchange/oob.test.js
+++ b/test/exchange/oob.test.js
@@ -1,7 +1,6 @@
 var chai = require('chai')
   , oob = require('../../lib/exchange/oob');
 
-
 describe('exchange.oob', function() {
   
   it('should be named oob', function() {
@@ -95,7 +94,7 @@ describe('exchange.oob', function() {
     });
   });
 
-  describe('handling a request with bad typed MFA token', function() {
+  describe('handling a request with non-string MFA token', function() {
     var response, err;
 
     before(function(done) {
@@ -161,7 +160,7 @@ describe('exchange.oob', function() {
     });
   });
 
-  describe('handling a request with a bad typed OOB code', function() {
+  describe('handling a request with a non-string OOB code', function() {
     var response, err;
 
     before(function(done) {

--- a/test/exchange/oob.test.js
+++ b/test/exchange/oob.test.js
@@ -193,7 +193,7 @@ describe('exchange.oob', function() {
     });
   });
 
-  describe('authenticating and issuing with token, body, and info', function() {
+  describe('authenticating and issuing with token, body, and info parameters', function() {
     var response, err;
 
     before(function(done) {

--- a/test/exchange/otp.test.js
+++ b/test/exchange/otp.test.js
@@ -60,7 +60,7 @@ describe('exchange.otp', function() {
     });
   });
   
-  describe('authenticating and issuing an access token based on scope', function() {
+  describe('authenticating and issuing an access token with token', function() {
     var response, err;
 
     before(function(done) {
@@ -70,12 +70,11 @@ describe('exchange.otp', function() {
         return done(null, { id: '1', username: 'johndoe' })
       }
       
-      function issue(client, user, otp, scope, done) {
+      function issue(client, user, otp, token, done) {
         if (client.id !== 'c123') { return done(new Error('incorrect client argument')); }
         if (user.username !== 'johndoe') { return done(new Error('incorrect user argument')); }
         if (otp !== '123456') { return done(new Error('incorrect otp argument')); }
-        if (scope.length !== 1) { return done(new Error('incorrect scope argument')); }
-        if (scope[0] !== 'execute') { return done(new Error('incorrect scope argument')); }
+        if (token !== 'ey...') { return done(new Error('incorrect token argument')); }
         
         return done(null, 's3cr1t')
       }
@@ -83,7 +82,7 @@ describe('exchange.otp', function() {
       chai.connect.use(otp(authenticate, issue))
         .req(function(req) {
           req.user = { id: 'c123', name: 'Example' };
-          req.body = { mfa_token: 'ey...', otp: '123456', scope: 'execute' };
+          req.body = { mfa_token: 'ey...', otp: '123456' };
         })
         .end(function(res) {
           response = res;
@@ -235,7 +234,7 @@ describe('exchange.otp', function() {
     });
   });
 
-  describe('authenticating and issuing an access token based on scope', function() {
+  describe('authenticating and issuing with token, body, and info', function() {
     var response, err;
 
     before(function(done) {
@@ -245,13 +244,12 @@ describe('exchange.otp', function() {
         return done(null, { id: '1', username: 'johndoe' }, { provider: 'XXX' })
       }
 
-      function issue(client, user, otp, scope, body, info, done) {
+      function issue(client, user, otp, token, body, info, done) {
         if (client.id !== 'c123') { return done(new Error('incorrect client argument')); }
         if (user.username !== 'johndoe') { return done(new Error('incorrect user argument')); }
         if (otp !== '123456') { return done(new Error('incorrect otp argument')); }
-        if (scope.length !== 1) { return done(new Error('incorrect scope argument')); }
-        if (scope[0] !== 'execute') { return done(new Error('incorrect scope argument')); }
-        if (body.mfa_token !== 'ey...' || body.otp !== '123456' || body.scope !== 'execute' ) {
+        if (token !== 'ey...') { return done(new Error('incorrect token argument')); }
+        if (body.mfa_token !== 'ey...' || body.otp !== '123456') {
           return done(new Error('incorrect body argument'));
         }
         if (info.provider !== 'XXX') { return done(new Error('incorrect info argument')); }
@@ -262,7 +260,7 @@ describe('exchange.otp', function() {
       chai.connect.use(otp(authenticate, issue))
         .req(function(req) {
           req.user = { id: 'c123', name: 'Example' };
-          req.body = { mfa_token: 'ey...', otp: '123456', scope: 'execute' };
+          req.body = { mfa_token: 'ey...', otp: '123456' };
         })
         .end(function(res) {
           response = res;

--- a/test/exchange/otp.test.js
+++ b/test/exchange/otp.test.js
@@ -234,7 +234,7 @@ describe('exchange.otp', function() {
     });
   });
 
-  describe('authenticating and issuing with token, body, and info', function() {
+  describe('authenticating and issuing with token, body, and info parameters', function() {
     var response, err;
 
     before(function(done) {

--- a/test/exchange/recoveryCode.test.js
+++ b/test/exchange/recoveryCode.test.js
@@ -60,7 +60,7 @@ describe('exchange.recoveryCode', function() {
     });
   });
 
-  describe('authenticating and issuing an access token based on scope', function() {
+  describe('authenticating and issuing an access token with token', function() {
     var response, err;
 
     before(function(done) {
@@ -70,12 +70,11 @@ describe('exchange.recoveryCode', function() {
         return done(null, { id: '1', username: 'johndoe' })
       }
 
-      function issue(client, user, recoveryCode, scope, done) {
+      function issue(client, user, recoveryCode, token, done) {
         if (client.id !== 'c123') { return done(new Error('incorrect client argument')); }
         if (user.username !== 'johndoe') { return done(new Error('incorrect user argument')); }
         if (recoveryCode !== '123456') { return done(new Error('incorrect recoveryCode argument')); }
-        if (scope.length !== 1) { return done(new Error('incorrect scope argument')); }
-        if (scope[0] !== 'execute') { return done(new Error('incorrect scope argument')); }
+        if (token !== 'ey...') { return done(new Error('incorrect token argument')); }
 
         return done(null, 's3cr1t')
       }
@@ -83,7 +82,7 @@ describe('exchange.recoveryCode', function() {
       chai.connect.use(recoveryCode(authenticate, issue))
         .req(function(req) {
           req.user = { id: 'c123', name: 'Example' };
-          req.body = { mfa_token: 'ey...', recovery_code: '123456', scope: 'execute' };
+          req.body = { mfa_token: 'ey...', recovery_code: '123456' };
         })
         .end(function(res) {
           response = res;
@@ -235,7 +234,7 @@ describe('exchange.recoveryCode', function() {
     });
   });
 
-  describe('authenticating and issuing an access token based on scope', function() {
+  describe('authenticating and issuing an access token with token, body, and info', function() {
     var response, err;
 
     before(function(done) {
@@ -245,13 +244,12 @@ describe('exchange.recoveryCode', function() {
         return done(null, { id: '1', username: 'johndoe' }, { provider: 'XXX' })
       }
 
-      function issue(client, user, recoveryCode, scope, body, info, done) {
+      function issue(client, user, recoveryCode, token, body, info, done) {
         if (client.id !== 'c123') { return done(new Error('incorrect client argument')); }
         if (user.username !== 'johndoe') { return done(new Error('incorrect user argument')); }
         if (recoveryCode !== '123456') { return done(new Error('incorrect recoveryCode argument')); }
-        if (scope.length !== 1) { return done(new Error('incorrect scope argument')); }
-        if (scope[0] !== 'execute') { return done(new Error('incorrect scope argument')); }
-        if (body.mfa_token !== 'ey...' || body.recovery_code !== '123456' || body.scope !== 'execute' ) {
+        if (token !== 'ey...') { return done(new Error('incorrect token argument')); }
+        if (body.mfa_token !== 'ey...' || body.recovery_code !== '123456') {
           return done(new Error('incorrect body argument'));
         }
         if (info.provider !== 'XXX') { return done(new Error('incorrect info argument')); }
@@ -262,7 +260,7 @@ describe('exchange.recoveryCode', function() {
       chai.connect.use(recoveryCode(authenticate, issue))
         .req(function(req) {
           req.user = { id: 'c123', name: 'Example' };
-          req.body = { mfa_token: 'ey...', recovery_code: '123456', scope: 'execute' };
+          req.body = { mfa_token: 'ey...', recovery_code: '123456' };
         })
         .end(function(res) {
           response = res;

--- a/test/exchange/recoveryCode.test.js
+++ b/test/exchange/recoveryCode.test.js
@@ -1,46 +1,46 @@
 var chai = require('chai')
-  , otp = require('../../lib/exchange/otp');
+  , recoveryCode = require('../../lib/exchange/recoveryCode');
 
-describe('exchange.otp', function() {
-  
-  it('should be named otp', function() {
-    expect(otp(function(){}, function(){}).name).to.equal('otp');
+describe('exchange.recoveryCode', function() {
+
+  it('should be named recoveryCode', function() {
+    expect(recoveryCode(function(){}, function(){}).name).to.equal('recovery_code');
   });
-  
+
   it('should throw if constructed without an authenticate callback', function() {
     expect(function() {
-      otp();
-    }).to.throw(TypeError, 'oauth2orize-mfa.otp exchange requires an authenticate callback');
+      recoveryCode();
+    }).to.throw(TypeError, 'oauth2orize-mfa.recoveryCode exchange requires an authenticate callback');
   });
-  
+
   it('should throw if constructed without an issue callback', function() {
     expect(function() {
-      otp(function(){});
-    }).to.throw(TypeError, 'oauth2orize-mfa.otp exchange requires an issue callback');
+      recoveryCode(function(){});
+    }).to.throw(TypeError, 'oauth2orize-mfa.recoveryCode exchange requires an issue callback');
   });
-  
+
   describe('authenticating and issuing an access token', function() {
     var response, err;
 
     before(function(done) {
       function authenticate(token, done) {
         if (token !== 'ey...') { return done(new Error('incorrect token argument')); }
-        
+
         return done(null, { id: '1', username: 'johndoe' })
       }
-      
-      function issue(client, user, otp, done) {
+
+      function issue(client, user, recoveryCode, done) {
         if (client.id !== 'c123') { return done(new Error('incorrect client argument')); }
         if (user.username !== 'johndoe') { return done(new Error('incorrect user argument')); }
-        if (otp !== '123456') { return done(new Error('incorrect otp argument')); }
-        
+        if (recoveryCode !== '123456') { return done(new Error('incorrect recoveryCode argument')); }
+
         return done(null, 's3cr1t')
       }
-      
-      chai.connect.use(otp(authenticate, issue))
+
+      chai.connect.use(recoveryCode(authenticate, issue))
         .req(function(req) {
           req.user = { id: 'c123', name: 'Example' };
-          req.body = { mfa_token: 'ey...', otp: '123456' };
+          req.body = { mfa_token: 'ey...', recovery_code: '123456' };
         })
         .end(function(res) {
           response = res;
@@ -48,42 +48,42 @@ describe('exchange.otp', function() {
         })
         .dispatch();
     });
-    
+
     it('should respond with headers', function() {
       expect(response.getHeader('Content-Type')).to.equal('application/json');
       expect(response.getHeader('Cache-Control')).to.equal('no-store');
       expect(response.getHeader('Pragma')).to.equal('no-cache');
     });
-    
+
     it('should respond with body', function() {
       expect(response.body).to.equal('{"access_token":"s3cr1t","token_type":"Bearer"}');
     });
   });
-  
+
   describe('authenticating and issuing an access token based on scope', function() {
     var response, err;
 
     before(function(done) {
       function authenticate(token, done) {
         if (token !== 'ey...') { return done(new Error('incorrect token argument')); }
-        
+
         return done(null, { id: '1', username: 'johndoe' })
       }
-      
-      function issue(client, user, otp, scope, done) {
+
+      function issue(client, user, recoveryCode, scope, done) {
         if (client.id !== 'c123') { return done(new Error('incorrect client argument')); }
         if (user.username !== 'johndoe') { return done(new Error('incorrect user argument')); }
-        if (otp !== '123456') { return done(new Error('incorrect otp argument')); }
+        if (recoveryCode !== '123456') { return done(new Error('incorrect recoveryCode argument')); }
         if (scope.length !== 1) { return done(new Error('incorrect scope argument')); }
         if (scope[0] !== 'execute') { return done(new Error('incorrect scope argument')); }
-        
+
         return done(null, 's3cr1t')
       }
-      
-      chai.connect.use(otp(authenticate, issue))
+
+      chai.connect.use(recoveryCode(authenticate, issue))
         .req(function(req) {
           req.user = { id: 'c123', name: 'Example' };
-          req.body = { mfa_token: 'ey...', otp: '123456', scope: 'execute' };
+          req.body = { mfa_token: 'ey...', recovery_code: '123456', scope: 'execute' };
         })
         .end(function(res) {
           response = res;
@@ -91,18 +91,18 @@ describe('exchange.otp', function() {
         })
         .dispatch();
     });
-    
+
     it('should respond with headers', function() {
       expect(response.getHeader('Content-Type')).to.equal('application/json');
       expect(response.getHeader('Cache-Control')).to.equal('no-store');
       expect(response.getHeader('Pragma')).to.equal('no-cache');
     });
-    
+
     it('should respond with body', function() {
       expect(response.body).to.equal('{"access_token":"s3cr1t","token_type":"Bearer"}');
     });
   });
-  
+
   describe('handling a request without an MFA token', function() {
     var response, err;
 
@@ -110,15 +110,15 @@ describe('exchange.otp', function() {
       function authenticate(token, done) {
         return done(null, { id: '0' })
       }
-      
-      function issue(client, user, otp, done) {
+
+      function issue(client, user, recoveryCode, done) {
         return done(null, '.ignore')
       }
-      
-      chai.connect.use(otp(authenticate, issue))
+
+      chai.connect.use(recoveryCode(authenticate, issue))
         .req(function(req) {
           req.user = { id: 'c123', name: 'Example' };
-          req.body = { otp: '123456' };
+          req.body = { recovery_code: '123456' };
         })
         .next(function(e) {
           err = e;
@@ -126,7 +126,7 @@ describe('exchange.otp', function() {
         })
         .dispatch();
     });
-    
+
     it('should error', function() {
       expect(err).to.be.an.instanceOf(Error);
       expect(err.constructor.name).to.equal('TokenError');
@@ -135,7 +135,7 @@ describe('exchange.otp', function() {
       expect(err.status).to.equal(400);
     });
   });
-  
+
   describe('handling a request with a non-string MFA token', function() {
     var response, err;
 
@@ -148,7 +148,7 @@ describe('exchange.otp', function() {
         return done(null, '.ignore')
       }
 
-      chai.connect.use(otp(authenticate, issue))
+      chai.connect.use(recoveryCode(authenticate, issue))
         .req(function(req) {
           req.user = { id: 'c123', name: 'Example' };
           req.body = { mfa_token: 1 };
@@ -169,19 +169,19 @@ describe('exchange.otp', function() {
     });
   });
 
-  describe('handling a request without a one-time password', function() {
+  describe('handling a request without a recovery code', function() {
     var response, err;
 
     before(function(done) {
       function authenticate(token, done) {
         return done(null, { id: '0' })
       }
-      
-      function issue(client, user, otp, done) {
+
+      function issue(client, user, recoveryCode, done) {
         return done(null, '.ignore')
       }
-      
-      chai.connect.use(otp(authenticate, issue))
+
+      chai.connect.use(recoveryCode(authenticate, issue))
         .req(function(req) {
           req.user = { id: 'c123', name: 'Example' };
           req.body = { mfa_token: 'ey...' };
@@ -192,17 +192,17 @@ describe('exchange.otp', function() {
         })
         .dispatch();
     });
-    
+
     it('should error', function() {
       expect(err).to.be.an.instanceOf(Error);
       expect(err.constructor.name).to.equal('TokenError');
-      expect(err.message).to.equal('Missing required parameter: otp');
+      expect(err.message).to.equal('Missing required parameter: recovery_code');
       expect(err.code).to.equal('invalid_request');
       expect(err.status).to.equal(400);
     });
   });
 
-  describe('handling a request with a non-string one-time password', function() {
+  describe('handling a request with a non-string recovery code', function() {
     var response, err;
 
     before(function(done) {
@@ -214,10 +214,10 @@ describe('exchange.otp', function() {
         return done(null, '.ignore')
       }
 
-      chai.connect.use(otp(authenticate, issue))
+      chai.connect.use(recoveryCode(authenticate, issue))
         .req(function(req) {
           req.user = { id: 'c123', name: 'Example' };
-          req.body = { otp: 1, mfa_token: 'foo' };
+          req.body = { recovery_code: 1, mfa_token: 'foo' };
         })
         .next(function(e) {
           err = e;
@@ -229,7 +229,7 @@ describe('exchange.otp', function() {
     it('should error', function() {
       expect(err).to.be.an.instanceOf(Error);
       expect(err.constructor.name).to.equal('TokenError');
-      expect(err.message).to.equal('otp must be a string');
+      expect(err.message).to.equal('recovery_code must be a string');
       expect(err.code).to.equal('invalid_request');
       expect(err.status).to.equal(400);
     });
@@ -245,13 +245,13 @@ describe('exchange.otp', function() {
         return done(null, { id: '1', username: 'johndoe' }, { provider: 'XXX' })
       }
 
-      function issue(client, user, otp, scope, body, info, done) {
+      function issue(client, user, recoveryCode, scope, body, info, done) {
         if (client.id !== 'c123') { return done(new Error('incorrect client argument')); }
         if (user.username !== 'johndoe') { return done(new Error('incorrect user argument')); }
-        if (otp !== '123456') { return done(new Error('incorrect otp argument')); }
+        if (recoveryCode !== '123456') { return done(new Error('incorrect recoveryCode argument')); }
         if (scope.length !== 1) { return done(new Error('incorrect scope argument')); }
         if (scope[0] !== 'execute') { return done(new Error('incorrect scope argument')); }
-        if (body.mfa_token !== 'ey...' || body.otp !== '123456' || body.scope !== 'execute' ) {
+        if (body.mfa_token !== 'ey...' || body.recovery_code !== '123456' || body.scope !== 'execute' ) {
           return done(new Error('incorrect body argument'));
         }
         if (info.provider !== 'XXX') { return done(new Error('incorrect info argument')); }
@@ -259,10 +259,10 @@ describe('exchange.otp', function() {
         return done(null, 's3cr1t')
       }
 
-      chai.connect.use(otp(authenticate, issue))
+      chai.connect.use(recoveryCode(authenticate, issue))
         .req(function(req) {
           req.user = { id: 'c123', name: 'Example' };
-          req.body = { mfa_token: 'ey...', otp: '123456', scope: 'execute' };
+          req.body = { mfa_token: 'ey...', recovery_code: '123456', scope: 'execute' };
         })
         .end(function(res) {
           response = res;

--- a/test/exchange/recoveryCode.test.js
+++ b/test/exchange/recoveryCode.test.js
@@ -234,7 +234,7 @@ describe('exchange.recoveryCode', function() {
     });
   });
 
-  describe('authenticating and issuing an access token with token, body, and info', function() {
+  describe('authenticating and issuing an access token with token, body, and info parameters', function() {
     var response, err;
 
     before(function(done) {

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -10,6 +10,7 @@ describe('oauth2orize-2fa', function() {
     expect(pkg.exchange).to.be.an('object');
     expect(pkg.exchange.otp).to.be.a('function');
     expect(pkg.exchange.oob).to.be.a('function');
+    expect(pkg.exchange.recoveryCode).to.be.a('function');
   });
   
 });


### PR DESCRIPTION
* Verify parameters on OTP and recovery-code
* Add recovery-code tests
* Provide the same interface for all exchanges (remove scope from OTP and recovery-code). Same approach as https://github.com/jaredhanson/oauth2orize-mfa/commit/426c61c8abfab0c207ccba7f7917361ea2222c51